### PR TITLE
feat(Flags): adding broadcasts and venue flags

### DIFF
--- a/commands/nhl.js
+++ b/commands/nhl.js
@@ -6,7 +6,7 @@ const querystring = require('querystring');
 module.exports = {
 	name: 'nhl',
 	usage: '<date> <team> <opponent> -<flag>',
-	description: 'Get games for \`today\`, \`tomorrow\`, \`yesterday\`, \`next\` 5 games, \`last\` 5 games, or a given date \`YYYY-MM-DD\`. If nothing is specified, games scheduled for today will return. Add abbreviations to filter for a specific team and opponent. Add flags \`-tv\` and/or \`-venue\`for more detail.',
+	description: 'Get games for `today`, `tomorrow`, `yesterday`, `next` 5 games, `last` 5 games, or a given date `YYYY-MM-DD`. If nothing is specified, games scheduled for today will return. Add abbreviations to filter for a specific team and opponent. Add flags `-tv` and/or `-venue`for more detail.',
 	category: 'scores',
 	aliases: ['nhl', 'n'],
 	examples: ['', 'nyi', 'tomorrow -tv -venue', 'next nyi nyr'],

--- a/commands/nhl.js
+++ b/commands/nhl.js
@@ -5,12 +5,12 @@ const querystring = require('querystring');
 
 module.exports = {
 	name: 'nhl',
-	usage: '<date> <team> <opponent>',
-	description: 'Get games for a tomorrow, yesterday, next 5 games, last 5 games, or given date (YYYY-MM-DD). If none is specified, return games scheduled for today.  Add team abbreviation to filter for a specific team and opponent.',
+	usage: '<date> <team> <opponent> -<flag>',
+	description: 'Get games for \`today\`, \`tomorrow\`, \`yesterday\`, \`next\` 5 games, \`last\` 5 games, or a given date \`YYYY-MM-DD\`. If nothing is specified, games scheduled for today will return. Add abbreviations to filter for a specific team and opponent. Add flags \`-tv\` and/or \`-venue\`for more detail.',
 	category: 'scores',
 	aliases: ['nhl', 'n'],
-	examples: ['', 'nyi', 'tomorrow', 'next nyi nyr'],
-	async execute(message, args, prefix) {
+	examples: ['', 'nyi', 'tomorrow -tv -venue', 'next nyi nyr'],
+	async execute(message, args, flags, prefix) {
 
 		const { teams } = await fetch('https://statsapi.web.nhl.com/api/v1/teams/').then(response => response.json());
 		const { seasons } = await fetch('https://statsapi.web.nhl.com/api/v1/seasons/current/').then(response => response.json());
@@ -79,8 +79,24 @@ module.exports = {
 			}
 		}
 
+		let expands = 'schedule.linescore';
+		let flagBroadcasts = false;
+		let flagVenue = false;
+		flags.forEach(flag => {
+			if (['tv', 't'].includes(flag)) {
+				expands += ',schedule.broadcasts';
+				flagBroadcasts = true;
+			}
+			else if (['venue', 'v'].includes(flag)) {
+				flagVenue = true;
+			}
+			else {
+				return message.channel.send(`\`-${flag}\` is not a valid flag. Type \`${prefix}help nhl\` for list of flags.`);
+			}
+		});
+
+		parameters.expand = expands;
 		parameters.gameType = ['PR', 'R', 'P', 'A'];
-		parameters.expand = ['schedule.linescore'];
 		const query = querystring.stringify(parameters);
 		const schedule = await fetch(endpoint + query).then(response => response.json());
 		const checkGames = schedule.totalGames;
@@ -109,25 +125,34 @@ module.exports = {
 					}
 				}
 
-				const { status: { statusCode }, teams: { away, home }, linescore } = game;
+				const { status: { statusCode }, teams: { away, home }, linescore, broadcasts, venue } = game;
 				const awayTeam = teams.find(o => o.id === away.team.id).abbreviation;
 				const homeTeam = teams.find(o => o.id === home.team.id).abbreviation;
 				const awayBB = isBold(away.score, home.score);
 				const homeBB = isBold(home.score, away.score);
+				let tv = '';
+				let arena = '';
+				if (broadcasts && flagBroadcasts) {
+					const channels = broadcasts.map(i => i.name).join(', ');
+					tv = '[' + channels + ']';
+				}
+				if (venue && flagVenue) {
+					arena = '[' + game.venue.name + ']';
+				}
 
 				if (statusCode < 3) {
 					const gameTimeEST = moment(game.gameDate).tz('America/New_York').format('h:mm A z');
-					return `${awayTeam} @ ${homeTeam} (${gameTimeEST})`;
+					return `${awayTeam} @ ${homeTeam} (${gameTimeEST}) ${arena} ${tv}`;
 				}
 				else if (statusCode > 2 && statusCode < 5) {
 					const awayPP = linescore.teams.away.powerPlay ? '[*PP*]' : '';
 					const homePP = linescore.teams.home.powerPlay ? '[*PP*]' : '';
 					const awayEN = linescore.teams.away.goaliePulled ? '[*EN*]' : '';
 					const homeEN = linescore.teams.home.goaliePulled ? '[*EN*]' : '';
-					return `${awayTeam} ${away.score} ${awayPP} ${awayEN} ${homeTeam} ${home.score} ${homePP} ${homeEN} (${linescore.currentPeriodTimeRemaining}/${linescore.currentPeriodOrdinal})`;
+					return `${awayTeam} ${away.score} ${awayPP} ${awayEN} ${homeTeam} ${home.score} ${homePP} ${homeEN} (${linescore.currentPeriodTimeRemaining}/${linescore.currentPeriodOrdinal}) ${arena} ${tv}`;
 				}
 				else if (statusCode > 5 && statusCode < 8) {
-					return `${awayBB}${awayTeam} ${away.score}${awayBB} ${homeBB}${homeTeam} ${home.score}${homeBB} (${formatPeriod(linescore.currentPeriodOrdinal)})`;
+					return `${awayBB}${awayTeam} ${away.score}${awayBB} ${homeBB}${homeTeam} ${home.score}${homeBB} (${formatPeriod(linescore.currentPeriodOrdinal)}) ${arena} ${tv}`;
 				}
 				else if (statusCode === 9) {
 					return `${awayTeam} @ ${homeTeam} PPD`;

--- a/index.js
+++ b/index.js
@@ -21,7 +21,8 @@ client.on('message', message => {
 
 	if (!message.content.startsWith(prefix) || !isNaN(message.content.substring(1, 2)) || message.author.bot) return;
 
-	const args = message.content.slice(prefix.length).split(/ +/);
+	const args = message.content.slice(prefix.length).split(/-\S+| /).filter(Boolean);
+	const flags = (message.content.match(/-([^\s]+)/g) || []).map(f => f.slice(1));
 	const commandName = args.shift().toLowerCase();
 	const command = client.commands.get(commandName) || client.commands.find(cmd => cmd.aliases && cmd.aliases.includes(commandName));
 
@@ -31,7 +32,7 @@ client.on('message', message => {
 		return message.reply(reply);
 	}
 	try {
-		command.execute(message, args, prefix);
+		command.execute(message, args, flags, prefix);
 	}
 	catch (error) {
 		console.error(error);


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
The NHL API `/schedule` endpoint provides optional modifiers that can give more detail about the scheduled or live games. Since these are optional and add significant amount of text to each scoreline, I've created a flag command system to allow the user to call it as desired. Venue is already provided in the API call by default, but adding `schedule.broadcasts` to `expand`, gives TV broadcasts information to the request. Also there was some cleanup and documentation done.

**Status**
- [x] Code changes have been tested against the NHL API, or there are no code changes

**Semantic versioning classification:**  
- [x] This PR changes the library's interface (methods or parameters added)
  - [ ] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [ ] This PR **only** includes non-code changes, like changes to documentation, README, etc.